### PR TITLE
feat: JDA 5.0.0-beta.5への対応、フォーク版lavaplayerへの変更、ローカルパスへの対応、CIの修正

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
       - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -22,8 +22,10 @@ jobs:
       matrix:
         language: [ 'java' ]
     steps:
-      - name: Checkout repository
+      - name: Checkout
         uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Set up JDK 17
         uses: actions/setup-java@v3

--- a/.github/workflows/qodana-quality.yml
+++ b/.github/workflows/qodana-quality.yml
@@ -13,7 +13,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - run: |
           sudo apt install -y tree
@@ -27,10 +30,11 @@ jobs:
 
       - name: Qodana Scan
         uses: JetBrains/qodana-action@v2022.3.4
+        timeout-minutes: 30
         with:
-          linter: jetbrains/qodana-jvm-community
-          fail-threshold: 100
           upload-result: true
+          args: "--linter,jetbrains/qodana-jvm-community,--fail-threshold,100"
+          use-caches: false
 
       - uses: github/codeql-action/upload-sarif@v2
         with:

--- a/pom.xml
+++ b/pom.xml
@@ -85,20 +85,20 @@
         <dependency>
             <groupId>net.dv8tion</groupId>
             <artifactId>JDA</artifactId>
-            <version>5.0.0-alpha.18</version>
+            <version>5.0.0-beta.5</version>
         </dependency>
         <dependency>
             <groupId>pw.chew</groupId>
             <artifactId>jda-chewtils</artifactId>
-            <version>2.0-interactions-SNAPSHOT</version>
+            <version>2.0-SNAPSHOT</version>
             <scope>compile</scope>
             <type>pom</type>
         </dependency>
         <!--suppress VulnerableLibrariesLocal -->
         <dependency>
-            <groupId>com.sedmelluq</groupId>
-            <artifactId>lavaplayer</artifactId>
-            <version>1.3.78</version>
+            <groupId>com.github.walkyst</groupId>
+            <artifactId>lavaplayer-fork</artifactId>
+            <version>1.3.99.2</version>
         </dependency>
         <dependency>
             <groupId>org.json</groupId>
@@ -108,7 +108,7 @@
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>okhttp</artifactId>
-            <version>5.0.0-SNAPSHOT</version>
+            <version>5.0.0-alpha.1</version>
         </dependency>
         <dependency>
             <groupId>ch.qos.logback</groupId>

--- a/src/main/java/com/jaoafa/jaotone/command/Cmd_Play.java
+++ b/src/main/java/com/jaoafa/jaotone/command/Cmd_Play.java
@@ -5,6 +5,9 @@ import com.jagrosh.jdautilities.command.CommandEvent;
 import com.jaoafa.jaotone.lib.ToneLib;
 import com.jaoafa.jaotone.player.PlayerManager;
 
+import java.nio.file.Files;
+import java.nio.file.Path;
+
 /**
  * コマンド: play
  * <p>
@@ -40,11 +43,15 @@ public class Cmd_Play extends Command {
         }
 
 
-        // クエリがURLかどうかを判定する
+        // クエリがURLかパスかどうかを判定する
         //noinspection HttpUrlsUsage
         if (query.startsWith("http://") || query.startsWith("https://")) {
             // URLの場合
             PlayerManager.getINSTANCE().loadAndPlay(event, event.getArgs(), event.getAuthor());
+            return;
+        } else if (Files.exists(Path.of(query))) {
+            // パスの場合
+            PlayerManager.getINSTANCE().loadAndPlay(event, query, event.getAuthor());
             return;
         }
 

--- a/src/main/java/com/jaoafa/jaotone/event/Event_AutoDisconnect.java
+++ b/src/main/java/com/jaoafa/jaotone/event/Event_AutoDisconnect.java
@@ -1,12 +1,9 @@
 package com.jaoafa.jaotone.event;
 
-import net.dv8tion.jda.api.entities.AudioChannel;
 import net.dv8tion.jda.api.entities.Guild;
-import net.dv8tion.jda.api.events.guild.voice.GuildVoiceLeaveEvent;
-import net.dv8tion.jda.api.events.guild.voice.GuildVoiceMoveEvent;
+import net.dv8tion.jda.api.entities.channel.unions.AudioChannelUnion;
+import net.dv8tion.jda.api.events.guild.voice.GuildVoiceUpdateEvent;
 import net.dv8tion.jda.api.hooks.ListenerAdapter;
-
-import javax.annotation.Nonnull;
 
 /**
  * 自動切断
@@ -19,16 +16,14 @@ import javax.annotation.Nonnull;
  */
 public class Event_AutoDisconnect extends ListenerAdapter {
     @Override
-    public void onGuildVoiceLeave(@Nonnull GuildVoiceLeaveEvent event) {
+    public void onGuildVoiceUpdate(GuildVoiceUpdateEvent event) {
+        if (event.getChannelLeft() == null) {
+            return;
+        }
         handler(event.getGuild(), event.getChannelLeft());
     }
 
-    @Override
-    public void onGuildVoiceMove(@Nonnull GuildVoiceMoveEvent event) {
-        handler(event.getGuild(), event.getChannelLeft());
-    }
-
-    void handler(Guild guild, AudioChannel channel) {
+    void handler(Guild guild, AudioChannelUnion channel) {
         if (!channel.getMembers().contains(guild.getSelfMember())) {
             return;
         }

--- a/src/main/java/com/jaoafa/jaotone/event/Event_QueueButton.java
+++ b/src/main/java/com/jaoafa/jaotone/event/Event_QueueButton.java
@@ -5,7 +5,6 @@ import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.events.interaction.component.ButtonInteractionEvent;
 import net.dv8tion.jda.api.hooks.ListenerAdapter;
 import net.dv8tion.jda.api.utils.messages.MessageCreateData;
-import org.jetbrains.annotations.NotNull;
 
 /**
  * イベント: QueueButton
@@ -16,7 +15,7 @@ import org.jetbrains.annotations.NotNull;
  */
 public class Event_QueueButton extends ListenerAdapter {
     @Override
-    public void onButtonInteraction(@NotNull ButtonInteractionEvent event) {
+    public void onButtonInteraction(ButtonInteractionEvent event) {
         if (!event.getComponentId().startsWith("queue:")) {
             return;
         }


### PR DESCRIPTION
- close #37 
- close #4 

---

すみません、適当に書いてたら1PRに色々混ざりまくりました

- [JDA 5.0.0-beta5](https://github.com/DV8FromTheWorld/JDA/releases/tag/v5.0.0-beta.5) に対応し、関連するコード修正を行いました。これにより、音源再生時に再生ができず入退室を繰り返す問題が解決されます。
- `play` コマンドにおけるクエリ処理に修正を加え、ローカルファイルの再生ができるようにしました。Docker内にマウントされた音源ファイルを再生することができるようになります。
- lavaplayerが2021年から更新がされていないことを鑑み、フォークされある程度活発に更新されている [Walkyst/lavaplayer-fork](https://github.com/Walkyst/lavaplayer-fork) への変更を行いました。
- 各種CIにおいて、checkoutのrefがおかしい問題を修正しました。
- 上記修正前に誤マージされてしまった、エラーの原因となるパッケージをダウングレードしました。