### PR TITLE
feat: PlayerManagerやTrackSchedulerの実装をJDA-VCSpeakerから流用

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,8 +22,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.11.0</version>
                 <configuration>
-                    <source>16</source>
-                    <target>16</target>
+                    <source>17</source>
+                    <target>17</target>
                 </configuration>
             </plugin>
             <plugin>

--- a/src/main/java/com/jaoafa/jaotone/command/Cmd_Clear.java
+++ b/src/main/java/com/jaoafa/jaotone/command/Cmd_Clear.java
@@ -29,7 +29,7 @@ public class Cmd_Clear extends Command {
             return;
         }
 
-        GuildMusicManager manager = PlayerManager.getINSTANCE().getGuildMusicManager(event.getGuild());
+        GuildMusicManager manager = PlayerManager.getGuildMusicManager(event.getGuild());
         manager.player.stopTrack();
         manager.scheduler.getQueue().clear();
         event.reactSuccess();

--- a/src/main/java/com/jaoafa/jaotone/command/Cmd_Disconnect.java
+++ b/src/main/java/com/jaoafa/jaotone/command/Cmd_Disconnect.java
@@ -3,7 +3,6 @@ package com.jaoafa.jaotone.command;
 import com.jagrosh.jdautilities.command.Command;
 import com.jagrosh.jdautilities.command.CommandEvent;
 import com.jaoafa.jaotone.lib.ToneLib;
-import com.jaoafa.jaotone.player.GuildMusicManager;
 import com.jaoafa.jaotone.player.PlayerManager;
 
 /**
@@ -30,9 +29,7 @@ public class Cmd_Disconnect extends Command {
             return;
         }
 
-        GuildMusicManager manager = PlayerManager.getINSTANCE().getGuildMusicManager(event.getGuild());
-        manager.player.stopTrack();
-        manager.scheduler.getQueue().clear();
+        PlayerManager.destroyGuildMusicManager(event.getGuild());
         event.getGuild().getAudioManager().closeAudioConnection();
         event.reactSuccess();
     }

--- a/src/main/java/com/jaoafa/jaotone/command/Cmd_NowPlaying.java
+++ b/src/main/java/com/jaoafa/jaotone/command/Cmd_NowPlaying.java
@@ -34,7 +34,7 @@ public class Cmd_NowPlaying extends Command {
             return;
         }
 
-        AudioTrack track = PlayerManager.getINSTANCE().getGuildMusicManager(event.getGuild()).player.getPlayingTrack();
+        AudioTrack track = PlayerManager.getGuildMusicManager(event.getGuild()).player.getPlayingTrack();
         if (track == null) {
             ToneLib.replyError(event, "再生中のトラックがありません。");
             return;

--- a/src/main/java/com/jaoafa/jaotone/command/Cmd_Pause.java
+++ b/src/main/java/com/jaoafa/jaotone/command/Cmd_Pause.java
@@ -30,7 +30,7 @@ public class Cmd_Pause extends Command {
             return;
         }
 
-        PlayerManager.getINSTANCE().getGuildMusicManager(event.getGuild()).player.setPaused(true);
+        PlayerManager.getGuildMusicManager(event.getGuild()).player.setPaused(true);
         event.reactSuccess();
     }
 }

--- a/src/main/java/com/jaoafa/jaotone/command/Cmd_Play.java
+++ b/src/main/java/com/jaoafa/jaotone/command/Cmd_Play.java
@@ -47,16 +47,16 @@ public class Cmd_Play extends Command {
         //noinspection HttpUrlsUsage
         if (query.startsWith("http://") || query.startsWith("https://")) {
             // URLの場合
-            PlayerManager.getINSTANCE().loadAndPlay(event, event.getArgs(), event.getAuthor());
+            PlayerManager.loadAndPlay(event, event.getArgs(), event.getAuthor());
             return;
         } else if (Files.exists(Path.of(query))) {
             // パスの場合
-            PlayerManager.getINSTANCE().loadAndPlay(event, query, event.getAuthor());
+            PlayerManager.loadAndPlay(event, query, event.getAuthor());
             return;
         }
 
         // 検索ワードの場合
         String searchQuery = String.format("ytsearch:%s", query);
-        PlayerManager.getINSTANCE().loadAndPlay(event, searchQuery, event.getAuthor());
+        PlayerManager.loadAndPlay(event, searchQuery, event.getAuthor());
     }
 }

--- a/src/main/java/com/jaoafa/jaotone/command/Cmd_Queue.java
+++ b/src/main/java/com/jaoafa/jaotone/command/Cmd_Queue.java
@@ -36,7 +36,7 @@ public class Cmd_Queue extends Command {
                 return;
             }
         }
-        MessageCreateData messageCreateData = PlayerManager.getINSTANCE().getQueueEmbed(event.getGuild(), page);
+        MessageCreateData messageCreateData = PlayerManager.getQueueEmbed(event.getGuild(), page);
         if (messageCreateData == null) {
             ToneLib.replyError(event, "キューが空です。");
             return;

--- a/src/main/java/com/jaoafa/jaotone/command/Cmd_Repeat.java
+++ b/src/main/java/com/jaoafa/jaotone/command/Cmd_Repeat.java
@@ -33,7 +33,7 @@ public class Cmd_Repeat extends Command {
             return;
         }
 
-        TrackScheduler scheduler = PlayerManager.getINSTANCE().getGuildMusicManager(event.getGuild()).scheduler;
+        TrackScheduler scheduler = PlayerManager.getGuildMusicManager(event.getGuild()).scheduler;
 
         if (event.getArgs().isEmpty()) {
             ToneLib.reply(event, "現在のリピート設定: `%s`".formatted(scheduler.getRepeatMode().getName()));

--- a/src/main/java/com/jaoafa/jaotone/command/Cmd_Resume.java
+++ b/src/main/java/com/jaoafa/jaotone/command/Cmd_Resume.java
@@ -30,7 +30,7 @@ public class Cmd_Resume extends Command {
             return;
         }
 
-        PlayerManager.getINSTANCE().getGuildMusicManager(event.getGuild()).player.setPaused(false);
+        PlayerManager.getGuildMusicManager(event.getGuild()).player.setPaused(false);
         event.reactSuccess();
     }
 }

--- a/src/main/java/com/jaoafa/jaotone/command/Cmd_Shuffle.java
+++ b/src/main/java/com/jaoafa/jaotone/command/Cmd_Shuffle.java
@@ -29,7 +29,7 @@ public class Cmd_Shuffle extends Command {
             return;
         }
 
-        PlayerManager.getINSTANCE().getGuildMusicManager(event.getGuild()).scheduler.shuffle();
+        PlayerManager.getGuildMusicManager(event.getGuild()).scheduler.shuffle();
         event.reactSuccess();
     }
 }

--- a/src/main/java/com/jaoafa/jaotone/command/Cmd_Skip.java
+++ b/src/main/java/com/jaoafa/jaotone/command/Cmd_Skip.java
@@ -29,7 +29,7 @@ public class Cmd_Skip extends Command {
             return;
         }
 
-        boolean result = PlayerManager.getINSTANCE().getGuildMusicManager(event.getGuild()).scheduler.nextTrack();
+        boolean result = PlayerManager.getGuildMusicManager(event.getGuild()).scheduler.nextTrack();
         if (!result) {
             event.reactError();
         } else {

--- a/src/main/java/com/jaoafa/jaotone/event/Event_AutoDisconnect.java
+++ b/src/main/java/com/jaoafa/jaotone/event/Event_AutoDisconnect.java
@@ -1,5 +1,6 @@
 package com.jaoafa.jaotone.event;
 
+import com.jaoafa.jaotone.player.PlayerManager;
 import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.entities.channel.unions.AudioChannelUnion;
 import net.dv8tion.jda.api.events.guild.voice.GuildVoiceUpdateEvent;
@@ -30,6 +31,7 @@ public class Event_AutoDisconnect extends ListenerAdapter {
         if (channel.getMembers().stream().anyMatch(member -> !member.getUser().isBot())) {
             return;
         }
+        PlayerManager.destroyGuildMusicManager(guild);
         guild.getAudioManager().closeAudioConnection();
     }
 }

--- a/src/main/java/com/jaoafa/jaotone/event/Event_QueueButton.java
+++ b/src/main/java/com/jaoafa/jaotone/event/Event_QueueButton.java
@@ -27,7 +27,7 @@ public class Event_QueueButton extends ListenerAdapter {
         String[] args = event.getComponentId().split(":");
         int page = Integer.parseInt(args[1]);
 
-        MessageCreateData messageCreateData = PlayerManager.getINSTANCE().getQueueEmbed(event.getGuild(), page);
+        MessageCreateData messageCreateData = PlayerManager.getQueueEmbed(event.getGuild(), page);
         if (messageCreateData == null) {
             if (refMessage == null) {
                 event.getChannel().sendMessage(":x: キューが空です。").queue();

--- a/src/main/java/com/jaoafa/jaotone/player/TrackScheduler.java
+++ b/src/main/java/com/jaoafa/jaotone/player/TrackScheduler.java
@@ -7,9 +7,7 @@ import com.sedmelluq.discord.lavaplayer.player.event.AudioEventAdapter;
 import com.sedmelluq.discord.lavaplayer.track.AudioTrack;
 import com.sedmelluq.discord.lavaplayer.track.AudioTrackEndReason;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
+import java.util.*;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 
@@ -78,7 +76,15 @@ public class TrackScheduler extends AudioEventAdapter {
         if (!endReason.mayStartNext) {
             return;
         }
-        nextTrack();
+        Timer timer = new Timer(false);
+        TimerTask task = new TimerTask() {
+            @Override
+            public void run() {
+                nextTrack();
+                timer.cancel();
+            }
+        };
+        timer.schedule(task, 300);
     }
 
     /**


### PR DESCRIPTION
- See https://github.com/jaoafa/jao-Minecraft-Server/issues/151

とりあえず、JDA-VCSpeakerでのPlayerManagerやTrackSchedulerの実装をそのまま流用することで、キュー処理周りが改善されることを願って…。