### PR TITLE
feat(deps): JDA を v5.3.1 から v6.4.1 へアップデート

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,10 +13,10 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 
-      - name: Set up JDK 17
+      - name: Set up JDK 25
         uses: actions/setup-java@v5
         with:
-          java-version: 17
+          java-version: 25
           distribution: adopt
 
       - name: Cache local Maven repository

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           java-version: 25
-          distribution: adopt
+          distribution: temurin
 
       - name: Cache local Maven repository
         uses: actions/cache@v5

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -27,10 +27,10 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 
-      - name: Set up JDK 17
+      - name: Set up JDK 25
         uses: actions/setup-java@v5
         with:
-          java-version: 17
+          java-version: 25
           distribution: adopt
 
       - name: Initialize CodeQL

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -31,7 +31,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           java-version: 25
-          distribution: adopt
+          distribution: temurin
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v4

--- a/.github/workflows/qodana-quality.yml
+++ b/.github/workflows/qodana-quality.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           java-version: 25
-          distribution: adopt
+          distribution: temurin
 
       - name: Qodana Scan
         uses: JetBrains/qodana-action@v2025.3.2

--- a/.github/workflows/qodana-quality.yml
+++ b/.github/workflows/qodana-quality.yml
@@ -22,10 +22,10 @@ jobs:
           sudo apt install -y tree
           tree -a -L 5 -I '.git'
 
-      - name: Set up JDK 17
+      - name: Set up JDK 25
         uses: actions/setup-java@v5
         with:
-          java-version: 17
+          java-version: 25
           distribution: adopt
 
       - name: Qodana Scan

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM maven:3 AS builder
+FROM maven:3-eclipse-temurin-25 AS builder
 
 WORKDIR /build
 COPY pom.xml /build/pom.xml

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,4 +27,4 @@ WORKDIR /app
 COPY --from=builder /build/target/jaoTone-jar-with-dependencies.jar .
 
 ENTRYPOINT []
-CMD ["java", "-jar", "jaoTone-jar-with-dependencies.jar"]
+CMD ["java", "--enable-native-access=ALL-UNNAMED", "-jar", "jaoTone-jar-with-dependencies.jar"]

--- a/pom.xml
+++ b/pom.xml
@@ -10,8 +10,8 @@
     <packaging>jar</packaging>
 
     <properties>
-        <maven.compiler.source>17</maven.compiler.source>
-        <maven.compiler.target>17</maven.compiler.target>
+        <maven.compiler.source>25</maven.compiler.source>
+        <maven.compiler.target>25</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
@@ -22,8 +22,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.15.0</version>
                 <configuration>
-                    <source>17</source>
-                    <target>17</target>
+                    <source>25</source>
+                    <target>25</target>
                 </configuration>
             </plugin>
             <plugin>
@@ -69,7 +69,7 @@
         <repository>
             <id>chew</id>
             <name>m2-chew</name>
-            <url>https://m2.chew.pro/snapshots/</url>
+            <url>https://m2.chew.pro/releases</url>
         </repository>
         <repository>
             <id>sonatype-public</id>
@@ -85,14 +85,24 @@
         <dependency>
             <groupId>net.dv8tion</groupId>
             <artifactId>JDA</artifactId>
-            <version>5.3.1</version>
+            <version>6.4.1</version>
         </dependency>
         <dependency>
             <groupId>pw.chew</groupId>
             <artifactId>jda-chewtils</artifactId>
-            <version>2.0-SNAPSHOT</version>
+            <version>2.2.1</version>
             <scope>compile</scope>
             <type>pom</type>
+        </dependency>
+        <dependency>
+            <groupId>club.minnced</groupId>
+            <artifactId>jdave-api</artifactId>
+            <version>0.1.8</version>
+        </dependency>
+        <dependency>
+            <groupId>club.minnced</groupId>
+            <artifactId>jdave-native-linux-x86-64</artifactId>
+            <version>0.1.8</version>
         </dependency>
         <!--suppress VulnerableLibrariesLocal -->
         <dependency>
@@ -108,7 +118,7 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>1.5.15</version>
+            <version>1.5.18</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/src/main/java/com/jaoafa/jaotone/Main.java
+++ b/src/main/java/com/jaoafa/jaotone/Main.java
@@ -98,9 +98,9 @@ public class Main {
 
             try {
                 commands.add(theClass.getDeclaredConstructor().newInstance());
-                logger.info("%s: コマンドの登録に成功しました".formatted(cmdName));
+                logger.info("{}: コマンドの登録に成功しました", cmdName);
             } catch (Throwable throwable) {
-                logger.error("%s: コマンドの登録に失敗しました".formatted(cmdName), throwable);
+                logger.error("{}: コマンドの登録に失敗しました", cmdName, throwable);
             }
         }
         builder.addCommands(commands.toArray(new Command[0]));
@@ -129,10 +129,10 @@ public class Main {
                 }
 
                 jdaBuilder.addEventListeners(instance);
-                logger.info("%s: イベントの登録に成功しました。".formatted(eventName));
+                logger.info("{}: イベントの登録に成功しました。", eventName);
             } catch (NoSuchMethodException | InstantiationException | IllegalAccessException |
                      InvocationTargetException e) {
-                logger.error("%s: イベントの登録に失敗しました。".formatted(eventName), e);
+                logger.error("{}: イベントの登録に失敗しました。", eventName, e);
             }
         }
     }

--- a/src/main/java/com/jaoafa/jaotone/Main.java
+++ b/src/main/java/com/jaoafa/jaotone/Main.java
@@ -5,7 +5,9 @@ import com.jagrosh.jdautilities.command.CommandClient;
 import com.jagrosh.jdautilities.command.CommandClientBuilder;
 import com.jagrosh.jdautilities.commons.waiter.EventWaiter;
 import com.jaoafa.jaotone.lib.ToneConfig;
+import club.minnced.discord.jdave.interop.JDaveSessionFactory;
 import net.dv8tion.jda.api.JDABuilder;
+import net.dv8tion.jda.api.audio.AudioModuleConfig;
 import net.dv8tion.jda.api.hooks.ListenerAdapter;
 import net.dv8tion.jda.api.requests.GatewayIntent;
 import org.reflections.Reflections;
@@ -39,6 +41,10 @@ public class Main {
 
         // ログイン
         try {
+            // Discord DAVE (E2E 暗号化) プロトコルの設定
+            AudioModuleConfig audioModuleConfig = new AudioModuleConfig()
+                    .withDaveSessionFactory(new JDaveSessionFactory());
+
             JDABuilder jdabuilder = JDABuilder
                     .createDefault(config.getToken())
                     .enableIntents(GatewayIntent.GUILD_MEMBERS,
@@ -47,7 +53,8 @@ public class Main {
                             GatewayIntent.GUILD_MESSAGE_REACTIONS)
                     .setAutoReconnect(true)
                     .setBulkDeleteSplittingEnabled(false)
-                    .setContextEnabled(false);
+                    .setContextEnabled(false)
+                    .setAudioModuleConfig(audioModuleConfig);
 
             jdabuilder.addEventListeners(waiter, client);
             registerEvent(jdabuilder);

--- a/src/main/java/com/jaoafa/jaotone/command/Cmd_Play.java
+++ b/src/main/java/com/jaoafa/jaotone/command/Cmd_Play.java
@@ -4,6 +4,7 @@ import com.jagrosh.jdautilities.command.Command;
 import com.jagrosh.jdautilities.command.CommandEvent;
 import com.jaoafa.jaotone.lib.ToneLib;
 import com.jaoafa.jaotone.player.PlayerManager;
+import net.dv8tion.jda.api.entities.channel.unions.AudioChannelUnion;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -39,7 +40,13 @@ public class Cmd_Play extends Command {
                 ToneLib.replyError(event, "ボイスチャンネルに参加していません。");
                 return;
             }
-            event.getGuild().getAudioManager().openAudioConnection(event.getMember().getVoiceState().getChannel());
+            // JDA v6 では inAudioChannel() が true でも getChannel() が null を返す可能性がある
+            AudioChannelUnion channel = event.getMember().getVoiceState().getChannel();
+            if (channel == null) {
+                ToneLib.replyError(event, "ボイスチャンネルに参加していません。");
+                return;
+            }
+            event.getGuild().getAudioManager().openAudioConnection(channel);
         }
 
 

--- a/src/main/java/com/jaoafa/jaotone/command/Cmd_Summon.java
+++ b/src/main/java/com/jaoafa/jaotone/command/Cmd_Summon.java
@@ -3,6 +3,7 @@ package com.jaoafa.jaotone.command;
 import com.jagrosh.jdautilities.command.Command;
 import com.jagrosh.jdautilities.command.CommandEvent;
 import com.jaoafa.jaotone.lib.ToneLib;
+import net.dv8tion.jda.api.entities.channel.unions.AudioChannelUnion;
 
 /**
  * コマンド: stop
@@ -26,7 +27,13 @@ public class Cmd_Summon extends Command {
             ToneLib.replyError(event, "ボイスチャンネルに参加していません。");
             return;
         }
-        event.getGuild().getAudioManager().openAudioConnection(event.getMember().getVoiceState().getChannel());
+        // JDA v6 では inAudioChannel() が true でも getChannel() が null を返す可能性がある
+        AudioChannelUnion channel = event.getMember().getVoiceState().getChannel();
+        if (channel == null) {
+            ToneLib.replyError(event, "ボイスチャンネルに参加していません。");
+            return;
+        }
+        event.getGuild().getAudioManager().openAudioConnection(channel);
         event.reactSuccess();
     }
 }

--- a/src/main/java/com/jaoafa/jaotone/player/PlayerManager.java
+++ b/src/main/java/com/jaoafa/jaotone/player/PlayerManager.java
@@ -94,7 +94,7 @@ public class PlayerManager {
         playerManager.loadItemOrdered(musicManager, trackUrl, new AudioLoadResultHandler() {
             @Override
             public void trackLoaded(AudioTrack track) {
-                Main.getLogger().info("trackLoaded: " + track.getInfo().title + " (" + track.getInfo().uri + ")");
+                Main.getLogger().info("trackLoaded: {} ({})", track.getInfo().title, track.getInfo().uri);
                 track.setUserData(event.getMessage());
                 musicManager.scheduler.queue(track);
                 event.reactSuccess();
@@ -108,7 +108,7 @@ public class PlayerManager {
                     ToneLib.reply(event, "検索結果の一件目 `%s` を再生します。".formatted(selectTrack.getInfo().title));
                     return;
                 }
-                Main.getLogger().info("playlistLoaded: " + playlist.getName() + " / " + playlist.getTracks().size());
+                Main.getLogger().info("playlistLoaded: {} / {}", playlist.getName(), playlist.getTracks().size());
                 for (AudioTrack track : playlist.getTracks()) {
                     track.setUserData(event.getMessage());
                     musicManager.scheduler.queue(track);
@@ -125,7 +125,7 @@ public class PlayerManager {
 
             @Override
             public void loadFailed(FriendlyException e) {
-                Main.getLogger().info("loadFailed: " + e.getMessage());
+                Main.getLogger().info("loadFailed: {}", e.getMessage());
                 ToneLib.replyError(event,
                         "トラックの読み込みに失敗しました: `%s(%s) -> %s`".formatted(e.getClass().getSimpleName(),
                                 e.severity.name(),

--- a/src/main/java/com/jaoafa/jaotone/player/PlayerManager.java
+++ b/src/main/java/com/jaoafa/jaotone/player/PlayerManager.java
@@ -21,7 +21,8 @@ import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.entities.User;
-import net.dv8tion.jda.api.interactions.components.buttons.Button;
+import net.dv8tion.jda.api.components.actionrow.ActionRow;
+import net.dv8tion.jda.api.components.buttons.Button;
 import net.dv8tion.jda.api.utils.messages.MessageCreateBuilder;
 import net.dv8tion.jda.api.utils.messages.MessageCreateData;
 
@@ -176,6 +177,6 @@ public class PlayerManager {
                 .secondary("queue:" + (page + 1), "次のページ")
                 .withDisabled(page == (int) Math.ceil((double) tracks.size() / 5));
 
-        return new MessageCreateBuilder().setEmbeds(builder.build()).addActionRow(prev, next).build();
+        return new MessageCreateBuilder().setEmbeds(builder.build()).addComponents(ActionRow.of(prev, next)).build();
     }
 }

--- a/src/main/java/com/jaoafa/jaotone/player/TrackScheduler.java
+++ b/src/main/java/com/jaoafa/jaotone/player/TrackScheduler.java
@@ -39,7 +39,7 @@ public class TrackScheduler extends AudioEventAdapter {
             return;
         }
         if (!queue.offer(track)) {
-            Main.getLogger().error("Failed to queue track: " + track.getInfo().title);
+            Main.getLogger().error("Failed to queue track: {}", track.getInfo().title);
         }
     }
 


### PR DESCRIPTION
## 概要

JDA (Java Discord API) を v5.3.1 から v6.4.1 へアップデートします。

## 変更内容

### 依存関係の更新

| 依存関係 | 変更前 | 変更後 |
|---|---|---|
| `net.dv8tion:JDA` | 5.3.1 | **6.4.1** |
| `pw.chew:jda-chewtils` | 2.0-SNAPSHOT | **2.2.1** |
| `ch.qos.logback:logback-classic` | 1.5.15 | **1.5.18** |

### 新規追加

- **`club.minnced:jdave-api:0.1.8`** — Discord DAVE (E2E 暗号化) プロトコル対応
- **`club.minnced:jdave-native-linux-x86-64:0.1.8`** — Linux 向けネイティブライブラリ

> **背景**: Discord は 2026年3月1日以降、DAVE プロトコルなしではボイス接続を拒否するようになっています。JDAVE は Java の Foreign Function & Memory (FFM) API を使用するため Java 25 が必要です。本プロジェクトは Docker on Linux (x86-64) のみで運用しているため、Linux 向けのネイティブライブラリのみを追加しています。

### Java バージョンの引き上げ

| 対象 | 変更前 | 変更後 |
|---|---|---|
| `pom.xml` (source/target) | Java 17 | **Java 25** |
| GitHub Actions CI (build.yml) | Java 17 | **Java 25** |
| GitHub Actions CI (codeql-analysis.yml) | Java 17 | **Java 25** |
| GitHub Actions CI (qodana-quality.yml) | Java 17 | **Java 25** |
| Dockerfile (本番) | Java 25.0.2 | 変更なし |

### その他の設定変更

- `jda-chewtils` のリポジトリ URL を `snapshots/` → `releases` に変更
- Dockerfile のビルダーイメージを `maven:3` → `maven:3-eclipse-temurin-25` に変更（JDK バージョンを明示固定）
- Dockerfile の起動コマンドに `--enable-native-access=ALL-UNNAMED` を追加（JDAVE の FFM API 使用に必要）
- GitHub Actions の JDK ディストリビューションを `adopt` → `temurin` に変更（AdoptOpenJDK はメンテナンス終了）

## JDA v6 API 変更への対応

JDA v5 → v6 の破壊的変更でコンパイルエラーが発生した箇所を修正しました。

### `PlayerManager.java`

| 変更前 | 変更後 |
|---|---|
| `import net.dv8tion.jda.api.interactions.components.buttons.Button` | `import net.dv8tion.jda.api.components.buttons.Button` |
| `.addActionRow(prev, next)` | `.addComponents(ActionRow.of(prev, next))` |

### `Main.java`

DAVE プロトコルのセットアップコードを追加しました。

```java
// Discord DAVE (E2E 暗号化) プロトコルの設定
AudioModuleConfig audioModuleConfig = new AudioModuleConfig()
        .withDaveSessionFactory(new JDaveSessionFactory());

JDABuilder jdabuilder = JDABuilder
        .createDefault(config.getToken())
        ...
        .setAudioModuleConfig(audioModuleConfig);
```