### PR TITLE
fix: YouTube 再生不具合の修正（YoutubeAudioSourceManager をコミュニティ保守版に移行）

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -114,7 +114,6 @@
             <artifactId>lavaplayer</artifactId>
             <version>2.2.6</version>
         </dependency>
-        <!-- YouTube の API 変更に追従するコミュニティ保守版ソースマネージャー（lavaplayer 2.x 対応） -->
         <dependency>
             <groupId>dev.lavalink.youtube</groupId>
             <artifactId>v2</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -79,6 +79,10 @@
             <id>jitpack.io</id>
             <url>https://jitpack.io</url>
         </repository>
+        <repository>
+            <id>lavalink-devs</id>
+            <url>https://maven.lavalink.dev/releases</url>
+        </repository>
     </repositories>
 
     <dependencies>
@@ -109,6 +113,12 @@
             <groupId>dev.arbjerg</groupId>
             <artifactId>lavaplayer</artifactId>
             <version>2.2.6</version>
+        </dependency>
+        <!-- YouTube の API 変更に追従するコミュニティ保守版ソースマネージャー（lavaplayer 2.x 対応） -->
+        <dependency>
+            <groupId>dev.lavalink.youtube</groupId>
+            <artifactId>v2</artifactId>
+            <version>1.18.0</version>
         </dependency>
         <dependency>
             <groupId>org.json</groupId>

--- a/renovate.json
+++ b/renovate.json
@@ -8,11 +8,5 @@
   "timezone": "Asia/Tokyo",
   "dependencyDashboard": false,
   "automerge": true,
-  "branchConcurrentLimit": 0,
-  "packageRules": [
-    {
-      "matchPackagePrefixes": ["dev.lavalink.youtube"],
-      "registryUrls": ["https://maven.lavalink.dev/releases"]
-    }
-  ]
+  "branchConcurrentLimit": 0
 }

--- a/renovate.json
+++ b/renovate.json
@@ -8,5 +8,11 @@
   "timezone": "Asia/Tokyo",
   "dependencyDashboard": false,
   "automerge": true,
-  "branchConcurrentLimit": 0
+  "branchConcurrentLimit": 0,
+  "packageRules": [
+    {
+      "matchPackagePrefixes": ["dev.lavalink.youtube"],
+      "registryUrls": ["https://maven.lavalink.dev/releases"]
+    }
+  ]
 }

--- a/src/main/java/com/jaoafa/jaotone/player/PlayerManager.java
+++ b/src/main/java/com/jaoafa/jaotone/player/PlayerManager.java
@@ -14,7 +14,7 @@ import com.sedmelluq.discord.lavaplayer.source.soundcloud.SoundCloudAudioSourceM
 import com.sedmelluq.discord.lavaplayer.source.twitch.TwitchStreamAudioSourceManager;
 import com.sedmelluq.discord.lavaplayer.source.vimeo.VimeoAudioSourceManager;
 import dev.lavalink.youtube.YoutubeAudioSourceManager;
-import dev.lavalink.youtube.clients.AndroidTestsuiteWithThumbnail;
+import dev.lavalink.youtube.clients.AndroidWithThumbnail;
 import dev.lavalink.youtube.clients.MusicWithThumbnail;
 import dev.lavalink.youtube.clients.WebWithThumbnail;
 import com.sedmelluq.discord.lavaplayer.tools.FriendlyException;
@@ -48,7 +48,7 @@ public class PlayerManager {
         playerManager.registerSourceManager(new YoutubeAudioSourceManager(
             true,
             new dev.lavalink.youtube.clients.skeleton.Client[]{
-                new MusicWithThumbnail(), new WebWithThumbnail(), new AndroidTestsuiteWithThumbnail()
+                new MusicWithThumbnail(), new WebWithThumbnail(), new AndroidWithThumbnail()
             }
         ));
         playerManager.registerSourceManager(SoundCloudAudioSourceManager.createDefault());

--- a/src/main/java/com/jaoafa/jaotone/player/PlayerManager.java
+++ b/src/main/java/com/jaoafa/jaotone/player/PlayerManager.java
@@ -13,7 +13,10 @@ import com.sedmelluq.discord.lavaplayer.source.getyarn.GetyarnAudioSourceManager
 import com.sedmelluq.discord.lavaplayer.source.soundcloud.SoundCloudAudioSourceManager;
 import com.sedmelluq.discord.lavaplayer.source.twitch.TwitchStreamAudioSourceManager;
 import com.sedmelluq.discord.lavaplayer.source.vimeo.VimeoAudioSourceManager;
-import com.sedmelluq.discord.lavaplayer.source.youtube.YoutubeAudioSourceManager;
+import dev.lavalink.youtube.YoutubeAudioSourceManager;
+import dev.lavalink.youtube.clients.AndroidTestsuiteWithThumbnail;
+import dev.lavalink.youtube.clients.MusicWithThumbnail;
+import dev.lavalink.youtube.clients.WebWithThumbnail;
 import com.sedmelluq.discord.lavaplayer.tools.FriendlyException;
 import com.sedmelluq.discord.lavaplayer.track.AudioPlaylist;
 import com.sedmelluq.discord.lavaplayer.track.AudioTrack;
@@ -41,7 +44,13 @@ public class PlayerManager {
 
     static {
         playerManager = new DefaultAudioPlayerManager();
-        playerManager.registerSourceManager(new YoutubeAudioSourceManager(true, null, null));
+        // YouTube の API 変更に追従するコミュニティ保守版ソースマネージャーを使用
+        playerManager.registerSourceManager(new YoutubeAudioSourceManager(
+            true,
+            new dev.lavalink.youtube.clients.skeleton.Client[]{
+                new MusicWithThumbnail(), new WebWithThumbnail(), new AndroidTestsuiteWithThumbnail()
+            }
+        ));
         playerManager.registerSourceManager(SoundCloudAudioSourceManager.createDefault());
         playerManager.registerSourceManager(new BandcampAudioSourceManager());
         playerManager.registerSourceManager(new VimeoAudioSourceManager());

--- a/src/main/java/com/jaoafa/jaotone/player/PlayerManager.java
+++ b/src/main/java/com/jaoafa/jaotone/player/PlayerManager.java
@@ -13,11 +13,12 @@ import com.sedmelluq.discord.lavaplayer.source.getyarn.GetyarnAudioSourceManager
 import com.sedmelluq.discord.lavaplayer.source.soundcloud.SoundCloudAudioSourceManager;
 import com.sedmelluq.discord.lavaplayer.source.twitch.TwitchStreamAudioSourceManager;
 import com.sedmelluq.discord.lavaplayer.source.vimeo.VimeoAudioSourceManager;
+import com.sedmelluq.discord.lavaplayer.tools.FriendlyException;
 import dev.lavalink.youtube.YoutubeAudioSourceManager;
 import dev.lavalink.youtube.clients.AndroidWithThumbnail;
 import dev.lavalink.youtube.clients.MusicWithThumbnail;
 import dev.lavalink.youtube.clients.WebWithThumbnail;
-import com.sedmelluq.discord.lavaplayer.tools.FriendlyException;
+import dev.lavalink.youtube.clients.skeleton.Client;
 import com.sedmelluq.discord.lavaplayer.track.AudioPlaylist;
 import com.sedmelluq.discord.lavaplayer.track.AudioTrack;
 import net.dv8tion.jda.api.EmbedBuilder;
@@ -44,10 +45,9 @@ public class PlayerManager {
 
     static {
         playerManager = new DefaultAudioPlayerManager();
-        // YouTube の API 変更に追従するコミュニティ保守版ソースマネージャーを使用
         playerManager.registerSourceManager(new YoutubeAudioSourceManager(
             true,
-            new dev.lavalink.youtube.clients.skeleton.Client[]{
+            new Client[]{
                 new MusicWithThumbnail(), new WebWithThumbnail(), new AndroidWithThumbnail()
             }
         ));


### PR DESCRIPTION
## Summary

- YouTube の player JS 変更により、`dev.arbjerg:lavaplayer` 組み込みの `YoutubeAudioSourceManager` がシグネチャ解析に失敗し YouTube 動画が再生できない問題を修正
- コミュニティが保守する `dev.lavalink.youtube:v2:1.18.0` に置き換えることで、YouTube の API 変更に追従できるようにした

## 主な変更点

### `pom.xml`
- `lavalink-devs` Maven リポジトリを追加
- `dev.lavalink.youtube:v2:1.18.0` 依存を追加

### `src/main/java/com/jaoafa/jaotone/player/PlayerManager.java`
- import を `com.sedmelluq.discord.lavaplayer.source.youtube.YoutubeAudioSourceManager` から `dev.lavalink.youtube.YoutubeAudioSourceManager` に変更
- `dev.lavalink.youtube.clients.skeleton.Client` を import に追加
- `registerSourceManager` の引数に `MusicWithThumbnail`、`WebWithThumbnail`、`AndroidWithThumbnail` クライアントを設定（複数クライアントへのフォールバックで安定性向上）

## テスト結果

- `mvn -B package` によりビルド成功を確認済み

- Closes #118